### PR TITLE
Fix for multiple values on "Link" header

### DIFF
--- a/lib/namespace.php
+++ b/lib/namespace.php
@@ -36,7 +36,8 @@ function discover_api_root( $uri, $legacy = false ) {
 	$response = Requests::head( $uri );
 	$response->throw_for_status();
 
-	$links = $response->headers->getValues( 'Link' );
+	$header_value = $response->headers->getValues( 'Link' );
+    	$links = explode( ',', $header_value[0] );
 
 	// Find the correct link by relation
 	foreach ( $links as $link ) {


### PR DESCRIPTION
Sample header value with page as front page ( added by wp_shortlink_header() ):
link →<http://www.site.com/wp-json/>; rel="http://api.w.org/", <https://www.site.com/>; rel=shortlink

Sample header value with posts as front page:
Link →<http://www.site.com/wp-json/>; rel="https://api.w.org/"